### PR TITLE
Add the CrossVersion.for3Use2_13 modifier to the readme instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ New applications should avoid this library.
 Add the following dependency to your project settings:
 
 ```scala
-libraryDependencies += "org.scala-js" %%% "scalajs-fake-weakreferences" % "1.0.0"
+libraryDependencies += ("org.scala-js" %%% "scalajs-fake-weakreferences" % "1.0.0").cross(CrossVersion.for3Use2_13)
 ```
 
 When using a `crossProject`, add the above in `.jsSettings(...)`.


### PR DESCRIPTION
So that Scala 3 users can use it without having to figure it out themselves.

---

This is a copy of https://github.com/scala-js/scala-js-weakreferences/pull/7